### PR TITLE
Add dynamic booking status actions UI

### DIFF
--- a/frontend/src/hooks/booking.js
+++ b/frontend/src/hooks/booking.js
@@ -70,7 +70,7 @@ const deleteBooking = async (bookingId) => {
 const updateBookingStatus = async ({ bookingId, status }) => {
 	const { data } = await axiosInstance({
 		url: `/bookings/${bookingId}/status`,
-		method: "PUT",
+		method: "PATCH",
 		data: { status },
 		headers: {
 			"Content-Type": "application/json",
@@ -83,7 +83,7 @@ const updateBookingStatus = async ({ bookingId, status }) => {
 const cancelBooking = async (bookingId) => {
 	const { data } = await axiosInstance({
 		url: `/bookings/${bookingId}/cancel`,
-		method: "POST",
+		method: "PATCH",
 		headers: {
 			"Content-Type": "application/json",
 		},

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -4,7 +4,11 @@ import Layout from "../components/Layout";
 import DataTable from "../components/DataTable";
 import Modal from "../components/Modal";
 import { AuthContext } from "../context";
-import { useGetBookings } from "../hooks/booking";
+import {
+	useGetBookings,
+	useUpdateBookingStatus,
+	useCancelBooking,
+} from "../hooks/booking";
 import BookingForm from "./BookSession/BookingForm";
 import { convertTimeToMinutes } from "../utils/functions";
 
@@ -14,8 +18,13 @@ function Sessions() {
 		role === "tutor"
 			? { view: activeView === "student" ? "student" : "tutor" }
 			: {};
+
 	const { data: sessions = [], isPending: isSessionsLoading } =
 		useGetBookings(bookingParams);
+
+	const updateBookingStatusMutation = useUpdateBookingStatus();
+	const cancelBookingMutation = useCancelBooking();
+
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -70,6 +79,66 @@ function Sessions() {
 		);
 	}, [filteredSessions]);
 
+	const handleStatusUpdate = (bookingId, status) => {
+		updateBookingStatusMutation.mutate({
+			bookingId,
+			status,
+		});
+	};
+
+	const handleCancelBooking = (bookingId) => {
+		cancelBookingMutation.mutate(bookingId);
+	};
+
+	const getStatusMeta = (status) => {
+		const normalizedStatus = (status || "pending").toLowerCase();
+
+		const statusMap = {
+			pending: {
+				label: "Pending",
+				className: "pending",
+			},
+			confirmed: {
+				label: "Confirmed",
+				className: "confirmed",
+			},
+			completed: {
+				label: "Completed",
+				className: "completed",
+			},
+			cancelled: {
+				label: "Cancelled",
+				className: "cancelled",
+			},
+		};
+
+		return (
+			statusMap[normalizedStatus] || {
+				label: normalizedStatus,
+				className: normalizedStatus,
+			}
+		);
+	};
+
+	const getAvailableActions = (status) => {
+		const normalizedStatus = (status || "pending").toLowerCase();
+
+		const actionMap = {
+			pending: [
+				{ value: "confirmed", label: "Mark as Confirmed" },
+				{ value: "cancelled", label: "Cancel Booking" },
+			],
+			confirmed: [
+				{ value: "completed", label: "Mark as Completed" },
+				{ value: "cancelled", label: "Cancel Booking" },
+			],
+			completed: [],
+			cancelled: [],
+		};
+
+		return actionMap[normalizedStatus] || [];
+	};
+
 	const columns = useMemo(
 		() => [
 			{
@@ -110,19 +179,93 @@ function Sessions() {
 			{
 				key: "status",
 				header: "Status",
-				render: (session) => (
-					<span className={`status-badge ${session.status || "pending"}`}>
-						{session.status || "pending"}
-					</span>
-				),
+				render: (session) => {
+					const statusMeta = getStatusMeta(session.status);
+
+					return (
+						<span className={`status-badge ${statusMeta.className}`}>
+							{statusMeta.label}
+						</span>
+					);
+				},
 			},
 			{
 				key: "notes",
 				header: "Notes",
 				render: (session) => session.notes || "No notes",
 			},
+			...(effectiveRole === "tutor" || effectiveRole === "admin"
+				? [
+						{
+							key: "actions",
+							header: "Actions",
+							render: (session) => {
+								const availableActions = getAvailableActions(session.status);
+								const isBusy =
+									updateBookingStatusMutation.isPending ||
+									cancelBookingMutation.isPending;
+
+								if (availableActions.length === 0) {
+									return (
+										<span
+											style={{
+												color: "#6b7280",
+												fontSize: "0.9rem",
+												fontWeight: 500,
+											}}>
+											No actions available
+										</span>
+									);
+								}
+
+								return (
+									<select
+										defaultValue=""
+										disabled={isBusy}
+										style={{
+											padding: "8px 10px",
+											borderRadius: "8px",
+											border: "1px solid #d1d5db",
+											backgroundColor: "#fff",
+											minWidth: "180px",
+											cursor: isBusy ? "not-allowed" : "pointer",
+										}}
+										onChange={(event) => {
+											const selectedValue = event.target.value;
+
+											if (!selectedValue) return;
+
+											if (selectedValue === "cancelled") {
+												handleCancelBooking(session._id);
+											} else {
+												handleStatusUpdate(session._id, selectedValue);
+											}
+
+											event.target.value = "";
+										}}>
+										<option value="">
+											{isBusy ? "Updating..." : "Choose action"}
+										</option>
+
+										{availableActions.map((action) => (
+											<option
+												key={action.value}
+												value={action.value}>
+												{action.label}
+											</option>
+										))}
+									</select>
+								);
+							},
+						},
+					]
+				: []),
 		],
-		[],
+		[
+			effectiveRole,
+			updateBookingStatusMutation.isPending,
+			cancelBookingMutation.isPending,
+		],
 	);
 
 	const pageTitle =

--- a/frontend/src/pages/Sessions.jsx
+++ b/frontend/src/pages/Sessions.jsx
@@ -11,6 +11,7 @@ import {
 } from "../hooks/booking";
 import BookingForm from "./BookSession/BookingForm";
 import { convertTimeToMinutes } from "../utils/functions";
+import Swal from "sweetalert2";
 
 function Sessions() {
 	const { user, role, activeView, effectiveRole } = useContext(AuthContext);
@@ -88,6 +89,32 @@ function Sessions() {
 
 	const handleCancelBooking = (bookingId) => {
 		cancelBookingMutation.mutate(bookingId);
+	};
+
+	const handleSessionAction = async (bookingId, action) => {
+		const actionLabels = {
+			confirmed: "confirm this booking",
+			completed: "mark this booking as completed",
+			cancelled: "cancel this booking",
+		};
+
+		const result = await Swal.fire({
+			title: "Confirmation",
+			text: `Are you sure you want to ${actionLabels[action]}?`,
+			icon: "question",
+			showCancelButton: true,
+			confirmButtonText: "Yes",
+			cancelButtonText: "Cancel",
+			reverseButtons: true,
+		});
+
+		if (!result.isConfirmed) return;
+
+		if (action === "cancelled") {
+			handleCancelBooking(bookingId);
+		} else {
+			handleStatusUpdate(bookingId, action);
+		}
 	};
 
 	const getStatusMeta = (status) => {
@@ -230,17 +257,12 @@ function Sessions() {
 											minWidth: "180px",
 											cursor: isBusy ? "not-allowed" : "pointer",
 										}}
-										onChange={(event) => {
+										onChange={async (event) => {
 											const selectedValue = event.target.value;
 
 											if (!selectedValue) return;
 
-											if (selectedValue === "cancelled") {
-												handleCancelBooking(session._id);
-											} else {
-												handleStatusUpdate(session._id, selectedValue);
-											}
-
+											await handleSessionAction(session._id, selectedValue);
 											event.target.value = "";
 										}}>
 										<option value="">


### PR DESCRIPTION
This PR adds a dynamic booking status action UI for sessions.

Changes made:
- added tutor/admin session action dropdown
- added dynamic status-based options
- connected status update and cancel actions
- fixed booking hook methods to match backend routes

Tested:
- booking status dropdown renders correctly
- confirm / complete / cancel actions trigger correctly
- UI refreshes after status change