### PR TITLE
fix: real tutor ratings + populate reviews on detail page

### DIFF
--- a/backend/controllers/tutorController.js
+++ b/backend/controllers/tutorController.js
@@ -1,5 +1,7 @@
+const mongoose = require("mongoose");
 const TutorApplication = require("../models/TutorApplication");
 const Booking = require("../models/Booking");
+const Review = require("../models/Review");
 const User = require("../models/User");
 const asyncHandler = require("../utils/asyncHandler");
 const ErrorResponse = require("../utils/errorResponse");
@@ -118,8 +120,35 @@ async function getBookingsByTutor(applications) {
 	}, new Map());
 }
 
-function formatTutorData(app, bookingsByTutor) {
+async function getReviewsByTutorUser(applications) {
+	const tutorUserIds = applications
+		.map((application) => application.user?.toString())
+		.filter(Boolean);
+
+	if (tutorUserIds.length === 0) {
+		return new Map();
+	}
+
+	const aggregates = await Review.aggregate([
+		{ $match: { tutor: { $in: tutorUserIds.map((id) => new mongoose.Types.ObjectId(id)) } } },
+		{
+			$group: {
+				_id: "$tutor",
+				avg: { $avg: "$rating" },
+				count: { $sum: 1 },
+			},
+		},
+	]);
+
+	return aggregates.reduce((map, row) => {
+		map.set(row._id.toString(), { avg: row.avg, count: row.count });
+		return map;
+	}, new Map());
+}
+
+function formatTutorData(app, bookingsByTutor, reviewsByTutorUser) {
 	const tutorUserId = app.user?.toString?.() || app.user;
+	const reviewStats = reviewsByTutorUser?.get(tutorUserId);
 
 	return {
 		_id: app._id,
@@ -133,7 +162,8 @@ function formatTutorData(app, bookingsByTutor) {
 		// The frontend compares generated slots against these booked ones.
 		bookedSlots: bookingsByTutor.get(app._id.toString()) || [],
 		status: app.status,
-		rating: 5,
+		rating: reviewStats?.avg ?? 0,
+		reviewCount: reviewStats?.count ?? 0,
 	};
 }
 
@@ -169,10 +199,15 @@ exports.getTutors = asyncHandler(async (req, res, next) => {
 		TutorApplication.countDocuments(query),
 	]);
 
-	const bookingsByTutor = await getBookingsByTutor(applications);
+	const [bookingsByTutor, reviewsByTutorUser] = await Promise.all([
+		getBookingsByTutor(applications),
+		getReviewsByTutorUser(applications),
+	]);
 
 	// Format data for frontend
-	const tutors = applications.map((app) => formatTutorData(app, bookingsByTutor));
+	const tutors = applications.map((app) =>
+		formatTutorData(app, bookingsByTutor, reviewsByTutorUser),
+	);
 
 	res.status(200).json({
 		success: true,
@@ -194,11 +229,14 @@ exports.getTutorById = asyncHandler(async (req, res, next) => {
 		return next(new ErrorResponse("Tutor not found", 404));
 	}
 
-	const bookingsByTutor = await getBookingsByTutor([tutor]);
+	const [bookingsByTutor, reviewsByTutorUser] = await Promise.all([
+		getBookingsByTutor([tutor]),
+		getReviewsByTutorUser([tutor]),
+	]);
 
 	res.status(200).json({
 		success: true,
-		data: formatTutorData(tutor, bookingsByTutor),
+		data: formatTutorData(tutor, bookingsByTutor, reviewsByTutorUser),
 	});
 });
 

--- a/frontend/src/pages/TutorDetail.jsx
+++ b/frontend/src/pages/TutorDetail.jsx
@@ -15,7 +15,7 @@ function TutorDetail() {
 	const {
 		data: reviewData = { reviews: [], count: 0, averageRating: 0 },
 		isPending: isReviewsLoading,
-	} = useGetTutorReviews(tutorId);
+	} = useGetTutorReviews(tutor?.userId);
 
 	const formatAvailabilitySlot = (slot) => {
 		if (!slot || typeof slot !== "object") return String(slot || "-");

--- a/frontend/src/pages/Tutors.jsx
+++ b/frontend/src/pages/Tutors.jsx
@@ -63,9 +63,13 @@ function Tutors() {
 											{tutor.course}
 										</p>
 									</div>
-									<Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">
-										★ {tutor.rating}
-									</Badge>
+									{tutor.reviewCount > 0 ? (
+										<Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">
+											★ {Number(tutor.rating).toFixed(1)} ({tutor.reviewCount})
+										</Badge>
+									) : (
+										<span className="text-xs text-slate-500">No reviews yet</span>
+									)}
 								</div>
 
 								<p className="text-sm text-slate-600">{tutor.bio}</p>


### PR DESCRIPTION
## Summary
Addresses teammate feedback on the reviews feature:

1. Tutor cards always showed "★ 5" because `formatTutorData` hardcoded `rating: 5`. Now aggregated from the `Review` collection; unreviewed tutors show "No reviews yet".
2. Reviews persisted in the DB but never appeared on the tutor detail page. Reviews are stored with `tutor: <User._id>`, but `TutorDetail.jsx` was fetching with the URL param, which is the `TutorApplication._id`. Now uses `tutor.userId` from the loaded tutor response.

## Changes
- `backend/controllers/tutorController.js` — adds `Review` + `mongoose` imports and a `getReviewsByTutorUser` helper that aggregates `{avg, count}` per tutor user id. `formatTutorData` returns `rating` (real average, `0` if none) and `reviewCount`.
- `frontend/src/pages/Tutors.jsx` — card shows `★ X.X (N)` when `reviewCount > 0`, otherwise a muted "No reviews yet".
- `frontend/src/pages/TutorDetail.jsx` — `useGetTutorReviews(tutor?.userId)` instead of the application id; the hook's `enabled` gate handles the initial undefined.

## Test plan
- [ ] Sign in as student, visit Tutors — an unreviewed tutor shows "No reviews yet"
- [ ] Leave a 4-star review on a completed session → that tutor's card now reads `★ 4.0 (1)`
- [ ] Add a 3-star review → card reads `★ 3.5 (2)`
- [ ] Open tutor detail page for a reviewed tutor → reviews list populates with stars + comments; header average matches
- [ ] Regression: unreviewed tutor detail page shows 0 stars and "0 reviews" (not 5)
- [ ] `cd backend && npm test` still passes (review.test.js untouched)