### PR TITLE
Add DockerHub publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: CD - Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+      - bijay-docker-cicd
+  workflow_dispatch:
+
+jobs:
+  docker-publish:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/tutorpro-backend:latest
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          build-args: |
+            VITE_API_URL=http://localhost:5050
+          tags: ${{ secrets.DOCKER_USERNAME }}/tutorpro-frontend:latest


### PR DESCRIPTION
This PR adds the DockerHub publish workflow for the CD part of the project.

Changes included:
- Added .github/workflows/docker-publish.yml
- Builds and pushes backend Docker image to DockerHub
- Builds and pushes frontend Docker image to DockerHub
- Uses GitHub Actions secrets for DockerHub authentication